### PR TITLE
refreshToken 쿠키에 저장, accessToken 만료 시 재발급 기능 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react": "^18.2.0",
     "react-avatar-edit": "^1.2.0",
     "react-avatar-editor": "^13.0.0",
+    "react-cookie": "^4.1.1",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.45.2",
     "react-query": "^3.39.3",

--- a/src/components/HeaderBar/index.tsx
+++ b/src/components/HeaderBar/index.tsx
@@ -5,6 +5,7 @@ import { useRecoilState, useResetRecoilState } from 'recoil';
 import { projectInfoMenuOpenState, SelectedProjectState } from '@states/ProjectState.ts';
 import { useNavigate } from 'react-router-dom';
 import { useCallback, useState } from 'react';
+import { removeCookie } from '@utils/cookie.ts';
 
 const HeaderBar = () => {
   const [projectInfoMenuOpen, setProjectInfoMenuOpen] = useRecoilState(projectInfoMenuOpenState);
@@ -17,7 +18,7 @@ const HeaderBar = () => {
   const onLogout = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     e.preventDefault();
     localStorage.removeItem('accessToken');
-    localStorage.removeItem('refreshToken');
+    removeCookie('refreshToken');
     setIsLogin(false);
     document.location.href = '/';
   }, []);

--- a/src/components/HeaderBar/index.tsx
+++ b/src/components/HeaderBar/index.tsx
@@ -17,6 +17,7 @@ const HeaderBar = () => {
   const onLogout = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     e.preventDefault();
     localStorage.removeItem('accessToken');
+    localStorage.removeItem('refreshToken');
     setIsLogin(false);
     document.location.href = '/';
   }, []);

--- a/src/components/SearchPassword/index.tsx
+++ b/src/components/SearchPassword/index.tsx
@@ -1,6 +1,6 @@
 import React, { ChangeEvent, FC, useCallback, useState } from 'react';
 
-import { toast, ToastContainer } from 'react-toastify';
+import { toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import axios, { AxiosError } from 'axios';
 

--- a/src/layouts/App/App.tsx
+++ b/src/layouts/App/App.tsx
@@ -58,7 +58,18 @@ function App() {
         </Routes>
       </BrowserRouter>
       <AddProject />
-      <ToastContainer position="top-center" autoClose={1500} closeOnClick pauseOnFocusLoss theme="light" />
+      <ToastContainer
+        position="top-center"
+        autoClose={3000}
+        hideProgressBar={false}
+        newestOnTop={false}
+        closeOnClick
+        rtl={false}
+        pauseOnFocusLoss
+        draggable
+        pauseOnHover
+        theme="light"
+      />
     </>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,16 +5,19 @@ import './index.css';
 import { RecoilRoot } from 'recoil';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
+import { CookiesProvider } from 'react-cookie';
 
 const queryClient = new QueryClient();
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <RecoilRoot>
-      <QueryClientProvider client={queryClient}>
-        <App />
-        <ReactQueryDevtools />
-      </QueryClientProvider>
-    </RecoilRoot>
+    <CookiesProvider>
+      <RecoilRoot>
+        <QueryClientProvider client={queryClient}>
+          <App />
+          <ReactQueryDevtools />
+        </QueryClientProvider>
+      </RecoilRoot>
+    </CookiesProvider>
   </React.StrictMode>
 );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,8 +6,38 @@ import { RecoilRoot } from 'recoil';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
 import { CookiesProvider } from 'react-cookie';
+import axios from 'axios';
+import { getCookie } from '@utils/cookie.ts';
+import { toast } from 'react-toastify';
 
 const queryClient = new QueryClient();
+
+axios.interceptors.response.use(
+  response => response,
+  async error => {
+    const originalRequest = error.config;
+
+    if (error.response.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+      const refreshToken = getCookie('refreshToken');
+      if (refreshToken) {
+        try {
+          const response = await axios.post('http://localhost:8080/access-tokens', { refreshToken });
+
+          const accessToken = response.data.accessToken;
+          localStorage.setItem('accessToken', accessToken);
+
+          originalRequest.headers['Authorization'] = `Bearer ${accessToken}`;
+          return axios(originalRequest);
+        } catch (refreshError) {
+          toast.error('에러에러에러');
+        }
+      }
+    }
+
+    return Promise.reject(error);
+  }
+);
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -50,6 +50,7 @@ const LogIn = () => {
       onMutate() {},
       onSuccess(data) {
         localStorage.setItem('accessToken', data?.accessToken);
+        localStorage.setItem('refreshToken', data?.refreshToken);
         navigate('/main');
       },
       onError(error) {

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useCallback, useState } from 'react';
+import { ChangeEvent, useCallback, useState } from 'react';
 import GoogleImg from '../../images/google-logo.png';
 import KakaoImg from '../../images/kakao-logo.png';
 
@@ -27,6 +27,7 @@ import { useMutation } from 'react-query';
 import axios, { AxiosError } from 'axios';
 import SearchPassword from '@components/SearchPassword';
 import { ToastContainer } from 'react-toastify';
+import { setCookie } from '@utils/cookie.ts';
 
 const LogIn = () => {
   const [email, onChangeEmail] = useInput('');
@@ -50,7 +51,7 @@ const LogIn = () => {
       onMutate() {},
       onSuccess(data) {
         localStorage.setItem('accessToken', data?.accessToken);
-        localStorage.setItem('refreshToken', data?.refreshToken);
+        setCookie('refreshToken', data?.refreshToken, { path: '/', secure: true });
         navigate('/main');
       },
       onError(error) {

--- a/src/pages/SignUp/index.tsx
+++ b/src/pages/SignUp/index.tsx
@@ -16,7 +16,7 @@ import { Link } from 'react-router-dom';
 import { useMutation } from 'react-query';
 import { IUser } from '@states/userState.ts';
 import axios, { AxiosError } from 'axios';
-import { toast, ToastContainer } from 'react-toastify';
+import { toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import { Button, Modal } from 'antd';
 import useInput from '../../hooks/useInput.ts';
@@ -118,18 +118,6 @@ const SignUp = () => {
   return (
     <>
       <Wrapper>
-        <ToastContainer
-          position="top-right"
-          autoClose={5000}
-          hideProgressBar={false}
-          newestOnTop={false}
-          closeOnClick
-          rtl={false}
-          pauseOnFocusLoss
-          draggable
-          pauseOnHover
-          theme="light"
-        ></ToastContainer>
         <Header>회원가입</Header>
         <SubHeader>
           <div>

--- a/src/states/userState.ts
+++ b/src/states/userState.ts
@@ -8,6 +8,7 @@ export interface IUser {
   emailAuthKey: string;
   checkPassword: string;
   accessToken: string;
+  refreshToken: string;
   error: any;
 }
 
@@ -19,6 +20,7 @@ const initialState: IUser = {
   emailAuthKey: '',
   checkPassword: '',
   accessToken: '',
+  refreshToken: '',
   error: '',
 };
 

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -1,0 +1,15 @@
+import { Cookies } from 'react-cookie';
+
+const cookie = new Cookies();
+
+export const setCookie = (name: string, value: string, option?: any) => {
+  return cookie.set(name, value, { ...option });
+};
+
+export const getCookie = (name: string) => {
+  return cookie.get(name);
+};
+
+export const removeCookie = (name: string) => {
+  return cookie.remove(name);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4347,6 +4347,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/cookie@npm:^0.3.3":
+  version: 0.3.3
+  resolution: "@types/cookie@npm:0.3.3"
+  checksum: 450c930d792a4fd5a93645b4123f02596368f904dbb1fe6fbb5043bce8f6ecf877a08511c6ba11c8e28168f62bc278e68d214f002fab927c9056c0bc69f21370
+  languageName: node
+  linkType: hard
+
 "@types/debug@npm:^4.0.0":
   version: 4.1.8
   resolution: "@types/debug@npm:4.1.8"
@@ -4436,6 +4443,16 @@ __metadata:
   version: 4.7.11
   resolution: "@types/history@npm:4.7.11"
   checksum: c92e2ba407dcab0581a9afdf98f533aa41b61a71133420a6d92b1ca9839f741ab1f9395b17454ba5b88cb86020b70b22d74a1950ccfbdfd9beeaa5459fdc3464
+  languageName: node
+  linkType: hard
+
+"@types/hoist-non-react-statics@npm:^3.0.1":
+  version: 3.3.1
+  resolution: "@types/hoist-non-react-statics@npm:3.3.1"
+  dependencies:
+    "@types/react": "*"
+    hoist-non-react-statics: ^3.3.0
+  checksum: 2c0778570d9a01d05afabc781b32163f28409bb98f7245c38d5eaf082416fdb73034003f5825eb5e21313044e8d2d9e1f3fe2831e345d3d1b1d20bcd12270719
   languageName: node
   linkType: hard
 
@@ -7140,6 +7157,13 @@ __metadata:
   version: 0.5.0
   resolution: "cookie@npm:0.5.0"
   checksum: 1f4bd2ca5765f8c9689a7e8954183f5332139eb72b6ff783d8947032ec1fdf43109852c178e21a953a30c0dd42257828185be01b49d1eb1a67fd054ca588a180
+  languageName: node
+  linkType: hard
+
+"cookie@npm:^0.4.0":
+  version: 0.4.2
+  resolution: "cookie@npm:0.4.2"
+  checksum: a00833c998bedf8e787b4c342defe5fa419abd96b32f4464f718b91022586b8f1bafbddd499288e75c037642493c83083da426c6a9080d309e3bd90fd11baa9b
   languageName: node
   linkType: hard
 
@@ -10170,7 +10194,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hoist-non-react-statics@npm:^3.3.1":
+"hoist-non-react-statics@npm:^3.0.0, hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.1":
   version: 3.3.2
   resolution: "hoist-non-react-statics@npm:3.3.2"
   dependencies:
@@ -12592,6 +12616,7 @@ __metadata:
     react: ^18.2.0
     react-avatar-edit: ^1.2.0
     react-avatar-editor: ^13.0.0
+    react-cookie: ^4.1.1
     react-dom: ^18.2.0
     react-hook-form: ^7.45.2
     react-query: ^3.39.3
@@ -16195,6 +16220,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-cookie@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "react-cookie@npm:4.1.1"
+  dependencies:
+    "@types/hoist-non-react-statics": ^3.0.1
+    hoist-non-react-statics: ^3.0.0
+    universal-cookie: ^4.0.0
+  peerDependencies:
+    react: ">= 16.3.0"
+  checksum: b734dcad35d790ced8c8fc3b19e3eb1f546e0923c637bad888c7c0096dbe2c996668416a49b48827ec7ad2d81522f1b57567694c791e1a5fb89ca41b39158a74
+  languageName: node
+  linkType: hard
+
 "react-dev-utils@npm:^12.0.1":
   version: 12.0.1
   resolution: "react-dev-utils@npm:12.0.1"
@@ -18789,6 +18827,16 @@ __metadata:
     unist-util-is: ^5.0.0
     unist-util-visit-parents: ^5.1.1
   checksum: 95a34e3f7b5b2d4b68fd722b6229972099eb97b6df18913eda44a5c11df8b1e27efe7206dd7b88c4ed244a48c474a5b2e2629ab79558ff9eb936840295549cee
+  languageName: node
+  linkType: hard
+
+"universal-cookie@npm:^4.0.0":
+  version: 4.0.4
+  resolution: "universal-cookie@npm:4.0.4"
+  dependencies:
+    "@types/cookie": ^0.3.3
+    cookie: ^0.4.0
+  checksum: bb2bafa7eb7e213e5448924329572dd1a913be00e23906189be2a0dc889b0eea1750f9c33462fc1c911d89092dbd82f6e220c2d61c4057bb3f69e7665d9d8ddf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## PR Checklist
아래 요구사항을 만족하는지 체크:

- [ ] 작성한 코드에 대한 테스트 코드 작성 (기능 추가 / 버그 개선)
- [ ] 작성한 코드 문서화 (기능 추가 / 버그 개선)


## PR Type
해당 PR이 포함하는 내용 체크:

- [ ] 패키지
  - [x] 패키지 추가
  - [ ] 패키지 설정 변경
- [ ] CI
  - [ ] CI 구성 추가
  - [ ] CI 설정 변경
- [ ] 문서화
  - [x] 신규 문서 추가
  - [ ] 기존 문서 변경
- [x] 신규 기능 추가
- [x] 버그 수정
- [ ] 코드 개선
  - [ ] 성능 개선
  - [ ] UI 개선
  - [ ] 성능에 영향을 끼치지 않는 수정
- [ ] 테스트
  - [ ] 테스트 코드 추가
  - [ ] 기존 테스트 코드 변경
- [ ] 커밋 되돌리기
- [ ] 기타


## 해당 PR에 대한 설명
utils에 쿠키 저장, 삭제, 조회 함수 추가 하였습니다.


Axios interceptor를 이용하여 http 통신을 하기 직전 실행하여 AxiosRequestConfig를 수정할수 있게 하였습니다.

api 요청 보내기 직전 토큰이 만료되었는지 확인 후 만료되었다면 저장된 refreshToken을 서버에 보내 새로운 accessToken을 발급받아 토큰을 교체하고 있습니다.

---

-react-toast
중복으로 뜨는 toast 알림 제거 하였습니다.

## 스크린샷


## 기타 정보